### PR TITLE
Fix typo in README regarding eco.earth package

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ range.arcto <- get_range(occ_coord = obs.arcto,
                         res = 0.05)
 ```
 
-Unlike at larger-scales, we have here decreased here the *get_gbif()* *grain* parameter from 100km to 1km, as keeping observations with a precision of 100km would have been too coarse to infer the approximate range distribution of the species relative to the study extent. *degrees_outlier* and *clust_pts_outlier* were here also kept defaults (~550 and 440 km, respectively), so relative to the study extent, almost no clustered or too distance observations were considered outliers.
+Unlike at larger-scales, we have here decreased the *get_gbif()* *grain* parameter from 100km to 1km, as keeping observations with a precision of 100km would have been too coarse to infer the approximate range distribution of the species relative to the study extent. *degrees_outlier* and *clust_pts_outlier* were here also kept defaults (~550 and 440 km, respectively), so relative to the study extent, almost no clustered or too distance observations were considered outliers.
 
 It is also important to note that the resolution parameter (*res*) can be changed to adjust how fine the spatial output should be. This highest possible resolution will only depend on the precision of the *bioreg* object (e.g., a range output can reach the same resolution of the rasters used to create a *make_ecoregion* object).
 


### PR DESCRIPTION
Corrected the spelling of 'earth' in the eco.earth package description.

Note: no certitude, but `eco.earh` when you also have `eco.marine` looks wrong.